### PR TITLE
Allowing jobs to be put on the queue by string ("module.klass") in addition to klass.

### DIFF
--- a/qless/queue.py
+++ b/qless/queue.py
@@ -51,7 +51,7 @@ class Queue(object):
             object.__setattr__(self, key, value)
    
     def class_string(self, klass):
-        if type(klass) == str:
+        if isinstance(klass,basestring):
             return klass
         return klass.__module__ + '.' + klass.__name__
  

--- a/test.py
+++ b/test.py
@@ -2462,6 +2462,14 @@ class TestPython(TestQless):
         self.assertRaises(AttributeError, lambda: job.foo)
         job['testing'] = 'foo'
         self.assertEqual(job['testing'], 'foo')
+ 
+    def test_job_by_unicode(self):
+        job = self.client.jobs[self.q.put(u'test.BarJob', {})]
+        self.assertTrue(job.jid in str(job))
+        self.assertTrue(job.jid in repr(job))
+        self.assertRaises(AttributeError, lambda: job.foo)
+        job['testing'] = 'foo'
+        self.assertEqual(job['testing'], 'foo')
     
     def test_queue(self):
         self.assertRaises(AttributeError, lambda: self.q.foo)


### PR DESCRIPTION
The rationale behind this is avoid forcing the job module to be importable from the caller code. 
This allows job code to only reside at the worker, it would ease up import headaches when using the queue from e.g. Django views and it would in principle allow for Python code to seamlessly put a job on the queue for a Ruby worker to consume. The same addition could be done in the Ruby client.
