### PR TITLE
Make the worker handle SIGTERM as well as SIGINT

### DIFF
--- a/qless/worker.py
+++ b/qless/worker.py
@@ -81,7 +81,10 @@ class Worker(object):
                 end   = ((i+1) * len(jids_to_resume)) / self.count
                 self.jids      = jids_to_resume[start:end]
                 return self.work()
-        
+
+        if self.master:
+            signal.signal(signal.SIGTERM, lambda s, f: self.stop())
+
         while self.master:
             try:
                 pid, status = os.wait()


### PR DESCRIPTION
We're using supervisor to start our qless-worker and when stopping something supervisor uses `SIGTERM` but the current worker only listen for `SIGINT` (`KeyboardInterrupt`).

I've added code to listen for `SIGTERM` which simply stops the worker.
