### PR TITLE
Fix for "No module named decorator" on fresh environment installs.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ stats, notifications, and a whole lot more.''',
         'ps': ['setproctitle']
     },
     install_requires     = [
-        'argparse', 'hiredis', 'redis', 'psutil', 'simplejson'],
+        'argparse', 'decorator', 'hiredis', 'redis', 'psutil', 'simplejson'],
     classifiers          = [
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',


### PR DESCRIPTION
Fixes regression from 4b26b5837ced0c2f76495b05b87e63e05f81c2af.
