### PR TITLE
Type error for qless-core default config values

### DIFF
--- a/qless/config.py
+++ b/qless/config.py
@@ -20,7 +20,10 @@ class Config(object):
         result = self._client('config.get', option)
         if not result:
             return None
-        return json.loads(result)
+        try:
+            return json.loads(result)
+        except TypeError:
+            return result
 
     def __setitem__(self, option, value):
         return self._client('config.set', option, value)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -72,3 +72,7 @@ class TestConfig(TestQless):
         self.assertNotEqual(self.client.config.all, updated)
         self.client.config.update(updated)
         self.assertEqual(self.client.config.all, updated)
+
+    def test_default_config(self):
+        '''We can get default config values.'''
+        self.assertEqual(self.client.config['heartbeat'], 60)


### PR DESCRIPTION
Querying a config value that has not been set from within the Python bindings produces a return value that is an integer, not a string value that can be passed to json.loads.  This change fixes issue #30 by checking for TypeError and returning the config value directly when that happens.