### PR TITLE
Importing a class works when there is no backing file

### DIFF
--- a/qless/job.py
+++ b/qless/job.py
@@ -70,9 +70,13 @@ class BaseJob(object):
         if klass not in BaseJob._loaded:
             BaseJob._loaded[klass] = time.time()
         if hasattr(mod, '__file__'):
-            mtime = os.stat(mod.__file__).st_mtime
-            if BaseJob._loaded[klass] < mtime:
-                mod = reload_module(mod)
+            try:
+                mtime = os.stat(mod.__file__).st_mtime
+                if BaseJob._loaded[klass] < mtime:
+                    mod = reload_module(mod)
+            except OSError:
+                logger.warn('Could not check modification time of %s',
+                    mod.__file__)
 
         return getattr(mod, klass.rpartition('.')[2])
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name                 = 'qless-py',
-    version              = '0.11.0',
+    version              = '0.11.1',
     description          = 'Redis-based Queue Management',
     long_description     = '''
 Redis-based queue management, with heartbeating, job tracking,

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -2,6 +2,7 @@
 
 import sys
 from six import PY3
+import mock
 
 from common import TestQless
 from qless.job import Job, BaseJob
@@ -202,6 +203,13 @@ class TestJob(TestQless):
         self.assertEqual(self.client.jobs['jid'].klass, Foo)
         Job.reload(self.client.jobs['jid'].klass_name)
         self.assertEqual(self.client.jobs['jid'].klass, Foo)
+
+    def test_no_mtime(self):
+        '''Don't blow up we cannot check the modification time of a module.'''
+        exc = OSError('Could not stat file')
+        with mock.patch('qless.job.os.stat', side_effect=exc):
+            Job._import('test_job.Foo')
+            Job._import('test_job.Foo')
 
 
 class TestRecurring(TestQless):

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py27,py33,py34,py35
 [testenv]
 deps =
   nose
+  mock
   gevent
   setproctitle
 commands =


### PR DESCRIPTION
Depending on the way a user's job class is installed, there may or may not be a backing file (it might be bundled up in the `.egg` instead). Currently the `Job` class checks a job class's module's file's modification time to see if needs to be reloaded, but this fails in the case where there is no corresponding file.

So, backoff that feature when unavailable.

I'm also lukewarm on the feature itself, but it is what's in place at the moment. Here is an example of one such stack trace:

```
Traceback (most recent call last):
  File "/var/lib/aardwolf/venv/bin/qless-py-worker", line 92, in <module>
    args.queue, qless.Client(args.host, hostname=args.name), **kwargs).run()
  File "/var/lib/aardwolf/venv/lib/python2.7/site-packages/qless/workers/forking.py", line 75, in run
    self.spawn(resume=resume[index], sandbox=sandbox).run()
  File "/var/lib/aardwolf/venv/lib/python2.7/site-packages/qless/workers/greenlet.py", line 73, in run
    job.klass
  File "/var/lib/aardwolf/venv/lib/python2.7/site-packages/qless/job.py", line 117, in __getattr__
    return BaseJob.__getattr__(self, key)
  File "/var/lib/aardwolf/venv/lib/python2.7/site-packages/qless/job.py", line 47, in __getattr__
    object.__setattr__(self, 'klass', self._import(self.klass_name))
  File "/var/lib/aardwolf/venv/lib/python2.7/site-packages/qless/job.py", line 72, in _import
    mtime = os.stat(mod.__file__).st_mtime
OSError: [Errno 20] Not a directory: '/var/lib/aardwolf/venv/lib/python2.7/site-packages/aardwolf-0.1.0-py2.7.egg/aardwolf/crawl/job.pyc'
```