### PR TITLE
Provide MANIFEST.in to include lua files.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include qless/qless-core/*.lua


### PR DESCRIPTION
@neilmb reported that the 0.11.1 Pypi release was broken, ultimately because none of the `qless-core` lua files was included. That is fallout from the switch to `setuptools` and the fact that we generally do `sdist`s (it ignores `package_data` in `setup.py` in this case, by all reports).

The solution is just to include a `MANIFEST.in` indicating that we should include the lua files.