### PR TITLE
show default values in commandline help

### DIFF
--- a/bin/qless-py-worker
+++ b/bin/qless-py-worker
@@ -4,7 +4,8 @@ import psutil
 import argparse
 
 # First off, read the arguments
-parser = argparse.ArgumentParser(description='Run qless workers.')
+parser = argparse.ArgumentParser(description='Run qless workers.',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 # Options specific to the client we're making'
 parser.add_argument('--host', dest='host', default='redis://localhost:6379',


### PR DESCRIPTION
this will add `(default: <value>)` to every argparse entries help output, very convenient for first time users