### PR TITLE
Remove psutil dependency

### DIFF
--- a/bin/qless-py-worker
+++ b/bin/qless-py-worker
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import psutil
+import multiprocessing as mp
 import argparse
 
 # First off, read the arguments
@@ -26,8 +26,7 @@ parser.add_argument('-d', '--workdir', default='.',
     help='The base work directory path')
 
 # Options specific to the worker we're instantiating
-num_cpus = psutil.NUM_CPUS if hasattr(psutil, 'NUM_CPUS') else psutil.cpu_count()
-parser.add_argument('-w', '--workers', default=num_cpus, type=int,
+parser.add_argument('-w', '--workers', default=mp.cpu_count(), type=int,
     help='How many processes to run. Set to 0 to use all available cores')
 parser.add_argument('-q', '--queue', action='append', default=[],
     help='The queues to pull work from')

--- a/bin/qless-py-worker
+++ b/bin/qless-py-worker
@@ -4,7 +4,8 @@ import psutil
 import argparse
 
 # First off, read the arguments
-parser = argparse.ArgumentParser(description='Run qless workers.')
+parser = argparse.ArgumentParser(description='Run qless workers.',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 # Options specific to the client we're making'
 parser.add_argument('--host', dest='host', default='redis://localhost:6379',

--- a/qless/workers/forking.py
+++ b/qless/workers/forking.py
@@ -1,7 +1,7 @@
 '''A worker that forks child processes'''
 
 import os
-import psutil
+import multiprocessing
 import signal
 
 from six import string_types
@@ -12,9 +12,9 @@ from qless import logger, util
 from .serial import SerialWorker
 
 try:
-    NUM_CPUS = psutil.cpu_count()
-except AttributeError:
-    NUM_CPUS = psutil.NUM_CPUS
+    NUM_CPUS = multiprocessing.cpu_count()
+except NotImplementedError:
+    NUM_CPUS = 1
 
 
 class ForkingWorker(Worker):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ hiredis==0.1.0
 mock==1.3.0
 nose==1.3.7
 pbr==1.8.1
-psutil==0.7.1
 redis==2.7.5
 setproctitle==1.1.5
 simplejson==3.3.0

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ stats, notifications, and a whole lot more.''',
         'decorator',
         'hiredis',
         'redis',
-        'psutil',
         'six',
         'simplejson'
     ],


### PR DESCRIPTION
This is an update to pull request #27 psutil is an unneeded dependency. I replaced it by multiprocessing, on of the python core modules.