### PR TITLE
BIG-3912 SIGQUIT in qless-py-worker

### DIFF
--- a/qless/workers/forking.py
+++ b/qless/workers/forking.py
@@ -108,10 +108,5 @@ class ForkingWorker(Worker):
     def handler(self, signum, frame):  # pragma: no cover
         '''Signal handler for this process'''
         if signum in (signal.SIGTERM, signal.SIGINT, signal.SIGQUIT):
-            for cpid in self.sandboxes:
-                try:
-                    os.kill(cpid, signum)
-                except OSError:  # pragma: no cover
-                    logger.exception(
-                        'Failed to send %s to %s...' % (signum, cpid))
+            self.stop(signum)
             os._exit(0)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name                 = 'qless-py',
-    version              = '0.11.2',
+    version              = '0.11.3',
     description          = 'Redis-based Queue Management',
     long_description     = '''
 Redis-based queue management, with heartbeating, job tracking,


### PR DESCRIPTION
The changes made in PR #46 fixed the issue of SIGQUIT not being sent to the child processes however we discovered that the signal handler was not waiting for the children to finish their work before the parent process was killed.  The `stop` method does wait so we are now using it in `handler`.  We tested this locally but were unable to write a test for it since it relies on `qless-py-worker`.

@dlecocq @neilmb @b4hand 