### PR TITLE
 Improve support for windows

### DIFF
--- a/bin/qless-py-worker
+++ b/bin/qless-py-worker
@@ -2,42 +2,52 @@
 
 import multiprocessing as mp
 import argparse
+import os
+import sys
+import qless
+from qless import logger
 
 # First off, read the arguments
-parser = argparse.ArgumentParser(description='Run qless workers.',
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser = argparse.ArgumentParser(
+    description='Run qless workers.',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 # Options specific to the client we're making'
 parser.add_argument('--host', dest='host', default='redis://localhost:6379',
-    help='The redis:// url to connect to')
+                    help='The redis:// url to connect to')
 parser.add_argument('-n', '--name', default=None, type=str,
-    help='The hostname to identify your worker as')
+                    help='The hostname to identify your worker as')
 
 # Options that we consume in this binary
 parser.add_argument('-p', '--path', action='append', default=[],
-    help='Path(s) to include when loading jobs')
+                    help='Path(s) to include when loading jobs')
 parser.add_argument('-v', '--verbose', default=False, action='store_true',
-    help='Be extra talkative')
+                    help='Be extra talkative')
 parser.add_argument('-l', '--logger', default=False, type=str,
-    help='Log out to this file')
+                    help='Log out to this file')
 parser.add_argument('-m', '--import', action='append', default=[],
-    help='The modules to preemptively import')
+                    help='The modules to preemptively import')
 parser.add_argument('-d', '--workdir', default='.',
-    help='The base work directory path')
+                    help='The base work directory path')
 
 # Options specific to the worker we're instantiating
+parser.add_argument('-t', '--type', default='serial',
+                    help='Worker type: serial or forking.')
 parser.add_argument('-w', '--workers', default=mp.cpu_count(), type=int,
-    help='How many processes to run. Set to 0 to use all available cores')
+                    help='How many processes to run. '
+                         'Set to 0 to use all available cores')
 parser.add_argument('-q', '--queue', action='append', default=[],
-    help='The queues to pull work from')
+                    help='The queues to pull work from')
 
 # Options specific to forking greenlet workers
 parser.add_argument('-g', '--greenlets', default=0, type=int,
-    help='How many greenlets to run in each process (if used, uses gevent)')
+                    help='How many greenlets to run in each process '
+                         '(if used, uses gevent)')
 parser.add_argument('-i', '--interval', default=60, type=int,
-    help='The polling interval')
+                    help='The polling interval')
 parser.add_argument('-r', '--resume', default=False, action='store_true',
-    help='Try to resume jobs that this worker had previously been working on')
+                    help='Try to resume jobs that this worker had '
+                         'previously been working on')
 args = parser.parse_args()
 
 # Build up the kwargs that we'll pass to the worker
@@ -56,11 +66,6 @@ if args.greenlets:
         'greenlets': args.greenlets
     })
 
-import os
-import sys
-import qless
-from qless import logger
-from qless.workers.forking import ForkingWorker
 
 # Add each of the paths to the python search path
 sys.path = [os.path.abspath(p) for p in args.path] + sys.path
@@ -90,5 +95,15 @@ for module in getattr(args, 'import'):
 os.chdir(args.workdir)
 
 # And now run the worker
-ForkingWorker(
-    args.queue, qless.Client(args.host, hostname=args.name), **kwargs).run()
+if args.type == 'serial':
+    from qless.workers.serial import SerialWorker
+    SerialWorker(args.queue,
+                 qless.Client(args.host, hostname=args.name),
+                 **kwargs).run()
+elif args.type == 'forking':
+    from qless.workers.forking import ForkingWorker
+    ForkingWorker(args.queue,
+                  qless.Client(args.host, hostname=args.name),
+                  **kwargs).run()
+else:
+    logger.exception('Unknown worker type: {}'.format(args.type))

--- a/qless/workers/forking.py
+++ b/qless/workers/forking.py
@@ -101,7 +101,7 @@ class ForkingWorker(Worker):
                     with Worker.sandbox(sandbox):
                         os.chdir(sandbox)
                         try:
-                           self.spawn(sandbox=sandbox).run()
+                            self.spawn(sandbox=sandbox).run()
                         except:
                             logger.exception('Exception in spawned worker')
                         finally:


### PR DESCRIPTION
qless-py-worker is a easy to use in Linux but is not so friendly to Window users. Though every user can define their own worker but I think it's useful to add some support in the original worker.
I made some changes to support Windows to some degree.
* More robust method to get signals that are supported by current operating systems.
* Add option to run serial or forking worker to qless-py-worker. Windows can only use serial worker.
And some code format are not preferred by PEP-8 style so I made some changes to them. But it is not so important and can be ignored and I can push a new commit.