### PR TITLE
Include required Python versions for Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ before_install:
   - make qless-core
   - sudo apt-get install -y libevent-dev python-all-dev python3-all-dev
 language: python
-env:
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=py35
-install: pip install tox
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+install: pip install tox tox-travis
 script: tox
 cache:
   directories:


### PR DESCRIPTION
Use tox-travis to run correct tox env for each Python version.